### PR TITLE
Fix press on the Ctrl key commits the conversion

### DIFF
--- a/extension/skk.js
+++ b/extension/skk.js
@@ -190,6 +190,9 @@ SKK.prototype.updateComposition = function() {
 
 SKK.prototype.handleKeyEvent = function(keyevent) {
   // Do not handle modifier only keyevent.
+  // 0xFFFD hack seems not working?
+  if (keyevent.ctrlKey && keyevent.key == "Ctrl") return false;
+  if (keyevent.altKey && keyevent.key == "Alt") return false;
   if (keyevent.key.charCodeAt(0) == 0xFFFD) {
     return false;
   }


### PR DESCRIPTION
For some reasons, a hack to determine whether a pressed key is a
modifier key or not no longer works.

```
keyevent.key.charCodeAt(0) == 0xFFFD
```

Instead, we need to call `keyevent.ctrlKey && keyevent.key == "Ctrl"` to
make sure it is the Ctrl key.  This change also makes sure that pressing
on the Alt key also is ignored.