### PR TITLE
Delete roman table entries for those starting with 'c'

### DIFF
--- a/extension/preedit_modes.js
+++ b/extension/preedit_modes.js
@@ -87,9 +87,6 @@ function preeditInput(skk, keyevent) {
   if (skk.preedit.length > 0 &&
       keyevent.shiftKey && 'A' <= keyevent.key && keyevent.key <= 'Z') {
     var key = keyevent.key.toLowerCase();
-    if (key == 'c') {
-      key = 'k';
-    }
     var okuriPrefix = (skk.roman.length > 0) ? skk.roman[0] : key;
     skk.processRoman(key, romanTable, function(text) {
         if (skk.roman.length > 0) {

--- a/extension/roman_table.js
+++ b/extension/roman_table.js
@@ -1,7 +1,6 @@
 var romanTable = {
   a:'\u3042', i:'\u3044', u:'\u3046', e:'\u3048', o:'\u304a',
   xa:'\u3041', xi:'\u3043', xu:'\u3045', xe:'\u3047', xo:'\u3049',
-  ca:'\u304b', ci:'\u304d', cu:'\u304f', ce:'\u3051', co:'\u3053',
   ka:'\u304b', ki:'\u304d', ku:'\u304f', ke:'\u3051', ko:'\u3053',
   ga:'\u304c', gi:'\u304e', gu:'\u3050', ge:'\u3052', go:'\u3054',
   sa:'\u3055', si:'\u3057', su:'\u3059', se:'\u305b', so:'\u305d',
@@ -47,7 +46,9 @@ var katakanaTable = {};
 
 (function() {
 function initRomanTable() {
-  var youons = ['c', 'k', 's', 't', 'n', 'h', 'm', 'r', 'g', 'd', 'b', 'p', 'z'];
+  var youons = ['k', 's', 't', 'n', 'h', 'm', 'r', 'g', 'd', 'b', 'p', 'z'];
+  // Add a mapping from "consonant + prefix + vowel" -> "consonant + i + small vowel"
+  // Ex. tya -> ti + small a, shu -> si + small u
   function addYouon(youon, prefix, base) {
     var mapping = {a:'\u3083', i:'\u3043', u:'\u3085',
                    e:'\u3047', o:'\u3087'};


### PR DESCRIPTION
事情はよく分からないけれど、 `c` を `k` に変換する処理のせいで `ccha` が `kcha` となっていた。この場合は最初の `kc` の時点で `k` が無視されて `c` が残ることになる。

どうやら全体的に `c` を `k` にマップする処理が入っているが、これは自分の知る限りでは一般的なローマ字の変換ではないので削除する。クレームが入ったら考える。