### PR TITLE
Ignore ctrl-j in roman mode

### DIFF
--- a/extension/roman_modes.js
+++ b/extension/roman_modes.js
@@ -24,6 +24,10 @@ function createRomanInput(table) {
       return true;
     }
 
+    if (keyevent.key == 'j' && keyevent.ctrlKey) {
+      return true;
+    }
+
     if (keyevent.key.length != 1 || keyevent.ctrlKey || keyevent.altKey) {
       return false;
     }


### PR DESCRIPTION
かなモード/カナモードのときに Ctrl-j でダウンロード履歴のタブが開くのを抑制します。

ddskkやいくつかのSKKクローンでは Ctrl-j が無視されることにより、
現在のモードがなんであれ Ctrl-j で変換を受け付ける状態になり、
それが使いやすいと思ったのでそうしました。