### PR TITLE
don't commit when q key pushed in ascii-preedit mode

### DIFF
--- a/extension/preedit_modes.js
+++ b/extension/preedit_modes.js
@@ -55,7 +55,7 @@ function preeditKeybind(skk, keyevent) {
     return true;
   }
 
-  if (keyevent.key == 'q') {
+  if (keyevent.key == 'q' && skk.currentMode != 'ascii-preedit') {
     skk.commitText(kanaTurnOver(skk.preedit));
     skk.preedit = '';
     skk.roman = '';


### PR DESCRIPTION
`/` を押して入力中に `q` を押しても確定しないようにしました。