### PR TITLE
preeditモードのときにlまたはLの入力でモードを切り替える

### DIFF
--- a/extension/preedit_modes.js
+++ b/extension/preedit_modes.js
@@ -62,6 +62,23 @@ function preeditKeybind(skk, keyevent) {
     skk.switchMode('hiragana');
     return true;
   }
+
+  if (keyevent.key == 'l' && skk.currentMode != 'ascii-preedit') {
+    skk.commitText(skk.preedit);
+    skk.preedit = '';
+    skk.roman = '';
+    skk.switchMode('ascii');
+    return true;
+  }
+
+  if (keyevent.key == 'L' && skk.currentMode != 'ascii-preedit') {
+    skk.commitText(skk.preedit);
+    skk.preedit = '';
+    skk.roman = '';
+    skk.switchMode('full-ascii');
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
preeditモードのときに l または L を入力すると、そこまでのひらがな入力を確定し、
l ならば半角英数字モード、L ならば全角英数字の入力モードになるようにしました。
ddskkがこの挙動だったので合わせました。