### PR TITLE
ひらがなモードでの!と?を全角にする

### DIFF
--- a/extension/roman_modes.js
+++ b/extension/roman_modes.js
@@ -70,6 +70,9 @@ function createRomanInput(table) {
           skk.caret += text.length;
         });
       return true;
+    } else if (keyevent.key == '!' || keyevent.key == '?') {
+      skk.processRoman(keyevent.key, table, skk.commitText.bind(skk));
+      return true;
     }
 
     return false;

--- a/extension/roman_table.js
+++ b/extension/roman_table.js
@@ -26,6 +26,8 @@ var romanTable = {
   '[': '\uff62', // 「
   ']': '\uff63', // 」
   '-': '\u30fc', // ー
+  '!': '\uff01', // ！
+  '?': '\uff1f', // ？
 
   // The following rule comes from https://github.com/skk-dev/ddskk/blob/8c47f46e38a29a0f3eabcd524268d20573102467/docs/06_apps.rst?plain=1#L2100-L2137
   'z ': '\u3000', // 全角スペース


### PR DESCRIPTION
ひらがなモードでの ! と ? の入力を、全角の！と？の入力にしました。
ddskkがその挙動だったので合わせましたが、
AquaSKKは半角の ! と ? ですし、おそらくそれぞれの開発者の考えがあってそうなってるのだと思いますので、
不要ならば却下してください。