### PR TITLE
変換中にXで辞書登録の削除をする

### DIFF
--- a/extension/conversion_modes.js
+++ b/extension/conversion_modes.js
@@ -59,6 +59,16 @@ function conversionMode(skk, keyevent) {
     skk.okuriText = '';
     skk.okuriPrefix = '';
     skk.switchMode('preedit');
+  } else if (keyevent.key == 'Shift') {
+    // do nothing
+  } else if (keyevent.key == 'X') {
+    var entry = skk.entries.entries[skk.entries.index];
+    skk.dictionary.removeUserEntry(skk.preedit + skk.okuriPrefix, entry.word);
+    skk.entries = null;
+    skk.preedit += skk.okuriText;
+    skk.okuriText = '';
+    skk.okuriPrefix = '';
+    skk.switchMode('preedit');
   } else {
     var is_commit_key = (
       keyevent.key == 'Enter' || (keyevent.key == 'j' && keyevent.ctrlKey));

--- a/extension/dictionary_loader.js
+++ b/extension/dictionary_loader.js
@@ -219,4 +219,28 @@ Dictionary.prototype.recordNewResult = function(reading, newEntry) {
   this.syncUserDictionary();
 };
 
+Dictionary.prototype.removeUserEntry = function(reading, word) {
+  var userEntries = this.userDict[reading] || [];
+  if (userEntries.length == 0) {
+    return;
+  }
+  var existing_i = -1;
+  for (var i = 0; i < userEntries.length; i++) {
+    if (userEntries[i].word == word) {
+      existing_i = i;
+      break;
+    }
+  }
+  if (existing_i < 0) {
+    return;
+  }
+  userEntries.splice(existing_i, 1);
+  if (userEntries.length > 0) {
+    this.userDict[reading] = userEntries;
+  } else {
+    delete this.userDict[reading];
+  }
+  this.syncUserDictionary();
+};
+
 })();


### PR DESCRIPTION
変換中に X を押すと辞書登録から単語を削除するようにしました。
ddskkなどの挙動では｢本当に削除するか｣という旨のダイアログを出した上で削除するのですが、
自分の理解度では難しそうだったので断念しました。