### PR TITLE
n を｢ん｣に確定すべき幾つかのキー

### DIFF
--- a/extension/preedit_modes.js
+++ b/extension/preedit_modes.js
@@ -159,6 +159,9 @@ function okuriPreeditInput(skk, keyevent) {
   if (keyevent.key == 'Enter' || (keyevent.key == 'j' && keyevent.ctrlKey)) {
     skk.commitText(skk.preedit);
     skk.preedit = '';
+    if (skk.roman == 'n') {
+      skk.commitText(romanTable['nn']);
+    }
     skk.roman = '';
     skk.switchMode('hiragana');
     return true;

--- a/extension/roman_modes.js
+++ b/extension/roman_modes.js
@@ -10,14 +10,13 @@ function updateComposition(skk) {
 function createRomanInput(table) {
   return function (skk, keyevent) {
     if (keyevent.key == 'Enter') {
-      if (skk.roman.length > 0) {
-        if (skk.roman == 'n') {
-          skk.commitText(((skk.currentMode == 'hiragana') ? romanTable : katakanaTable)['nn']);
-        } else {
-          skk.commitText('');
-        }
-        skk.roman = '';
+      if (skk.roman == 'n') {
+        const table = (skk.currentMode == 'hiragana') ? romanTable : katakanaTable;
+        skk.commitText(table['nn']);
+      } else if (skk.roman.length > 0) {
+        skk.commitText('');
       }
+      skk.roman = '';
       return false;
     }
 


### PR DESCRIPTION
`skk.roman == 'n'` を｢ん｣に確定すべき場面があります

| モード | Enter | q | l | L |
|:---:|:---:|:---:|:---:|:---:|
| hira/kata | 修正 (改行は必要か?) | 問題なし | 問題なし | 問題なし |
| preedit | 修正 | 修正  | 修正 | 修正 |

その他はよく分かりません
というか、l / L も本当にこれで良いのか自信ありません

あと hiragana/katakana モードで skk.roman が (n 以外でも) 残ったまま Enter したときの動作がバグってたので手を入れました
正しい動作かどうかは分かりませんが、n 以外の roman は無視して (消去して) 改行するようにしてあります
emacs dd-skk で動作確認すると良いのかもしれませんが、面倒なので調べていません

なお、次々と報告しているのは私が忘れないようにしているだけで、急ぐわけではありません
いつでも大丈夫です
丁寧に対応していただいて、ありがとうございます