### PR TITLE
preedit の補完機能を追加

### DIFF
--- a/extension/conversion_modes.js
+++ b/extension/conversion_modes.js
@@ -20,7 +20,7 @@ function updateComposition(skk) {
 function initConversion(skk) {
   skk.lookup(skk.preedit + skk.okuriPrefix, function(entries) {
     if (entries) {
-      skk.entries = {index:0, entries:entries};
+      skk.entries = {index:0, entries:entries, label:'asdfjkl'};
       updateComposition(skk);
     } else {
       skk.createInnerSKK();

--- a/extension/conversion_modes.js
+++ b/extension/conversion_modes.js
@@ -10,10 +10,7 @@ function updateComposition(skk) {
   if (skk.okuriText.length > 0) {
     preedit += skk.okuriText;
   }
-  if (entry.annotation) {
-    preedit += ';' + entry.annotation;
-  }
-  skk.setComposition(preedit, 1, {selectionStart:preedit.length,
+  skk.setComposition(preedit, 1, {selectionStart:1,
                                   selectionEnd:preedit.length});
 }
 

--- a/extension/dictionary_loader.js
+++ b/extension/dictionary_loader.js
@@ -196,13 +196,6 @@ Dictionary.prototype.lookup = function(reading) {
 };
 
 Dictionary.prototype.recordNewResult = function(reading, newEntry) {
-  var entries = this.lookup(reading);
-
-  // Not necessary to modify the user dictionary if it's already the top.
-  if (entries && entries.data[0].word == newEntry.word) {
-    return;
-  }
-
   var userEntries = this.userDict[reading];
   if (userEntries == null) {
     this.userDict[reading] = [newEntry];
@@ -246,5 +239,28 @@ Dictionary.prototype.removeUserEntry = function(reading, word) {
   }
   this.syncUserDictionary();
 };
+
+function complete(dict, reading) {
+  if (!reading || reading.length == 0) {
+    return [];
+  }
+  return Object.keys(dict)
+    .filter((key) => key.startsWith(reading))
+    .map((key) => {
+      const roman = key.match(/[a-z]*$/)[0];
+      if (roman.length > 0) {
+        return key.slice(0, -roman.length);
+      }
+      return key;
+    });
+}
+
+Dictionary.prototype.userComplete = function(reading) {
+  return complete(this.userDict, reading);
+}
+
+Dictionary.prototype.systemComplete = function(reading) {
+  return complete(this.systemDict, reading);
+}
 
 })();

--- a/extension/preedit_modes.js
+++ b/extension/preedit_modes.js
@@ -24,9 +24,7 @@ function preeditKeybind(skk, keyevent) {
       skk.preedit = skk.oldPreedit;
       skk.roman = skk.oldRoman;
       skk.caret = skk.preedit.length;
-      skk.entries = null;
-      skk.updateCandidates();
-      skk.tabbing = null;
+      skk.userComplete();
       return true;
     }
     skk.preedit = '';

--- a/extension/preedit_modes.js
+++ b/extension/preedit_modes.js
@@ -38,9 +38,18 @@ function preeditKeybind(skk, keyevent) {
       skk.tabbing = 'user';
       skk.oldPreedit = skk.preedit;
       skk.oldRoman = skk.roman;
-    }
-    if (skk.entries) {
-      skk.entries.index++;
+      if (keyevent.shiftKey && skk.entries) {
+        skk.entries.index = skk.entries.entries.length - 1;
+      }
+    } else if (skk.entries) {
+      if (!keyevent.shiftKey) {
+        skk.entries.index++;
+      } else {
+        skk.entries.index--;
+        if (skk.entries.index < 3) {
+          skk.entries.index = skk.entries.entries.length - 1;
+        }
+      }
     }
     if (!skk.entries || skk.entries.index >= skk.entries.entries.length) {
       skk.preedit = skk.oldPreedit;
@@ -50,6 +59,8 @@ function preeditKeybind(skk, keyevent) {
       if (!skk.entries) {
         skk.userComplete();
         return true;
+      } else if (keyevent.shiftKey) {
+        skk.entries.index = skk.entries.entries.length - 1;
       }
     }
     skk.preedit = skk.entries.entries[skk.entries.index].word;

--- a/extension/roman_modes.js
+++ b/extension/roman_modes.js
@@ -76,6 +76,7 @@ function createRomanInput(table) {
             text + skk.preedit.slice(skk.caret);
           skk.caret += text.length;
         });
+      skk.userComplete();
       return true;
     } else if (keyevent.key == '!' || keyevent.key == '?') {
       skk.processRoman(keyevent.key, table, skk.commitText.bind(skk));

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -51,7 +51,8 @@ SKK.prototype.updateCandidates = function() {
       engineID:this.engineID,
       properties:{
         visible:false
-      }});
+      }
+    }).catch((e) => console.log(e));
     return;
   }
 
@@ -93,7 +94,7 @@ SKK.prototype.updateCandidates = function() {
         auxiliaryText:this.entries.text,
         auxiliaryTextVisible:!!this.entries.text
       }
-    })
+    }).catch((e) => console.log(e))
   ).then(() =>
     chrome.input.ime.setCursorPosition({
       contextID:this.context, candidateID:this.entries.index
@@ -441,7 +442,7 @@ SKK.prototype.showStatus = function() {
         pageSize:1,
         auxiliaryTextVisible:false
       }
-    })
+    }).catch((e) => console.log(e))
   ).then(() => {
     clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
@@ -452,7 +453,7 @@ SKK.prototype.showStatus = function() {
           properties:{
             visible:false
           }
-        });
+        }).catch((e) => console.log(e));
       }
     }, 2500);
   }).catch((e) => console.log(e));

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -125,8 +125,7 @@ SKK.prototype.complete = function(dict_complete, text) {
     .sort((a, b) => b.length - a.length)
   );
   if (entries.length > 0) {
-    const candidates = ['', '', ''];
-    candidates.push(...new Set(entries));
+    const candidates = ['', '', '', ...new Set(entries)];
     this.entries = {
       index:3,
       entries:candidates.map((e) => ({word:e})),

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -57,20 +57,18 @@ SKK.prototype.updateCandidates = function() {
   }
 
   const candidates = [];
-  const noList = this.entries ? this.entries.index <= 2 : true;
+  const noList = this.entries.index <= 2;
   const pageSize = noList ? 3 : 7;
+  const start = noList ? 0 : this.entries.index;
+  const remaining = Math.max(0, this.entries.entries.length - start - pageSize);
+  if (!this.entries.text || this.entries.text.startsWith('+ ')) {
+    this.entries.text = '+ ' + remaining;
+  }
 
   for (var i = 0; i < pageSize; i++) {
-    const start = noList ? 0 : this.entries.index;
     if (start + i >= this.entries.entries.length) {
       break;
     }
-
-    const remaining = Math.max(0, this.entries.entries.length - start - pageSize);
-    if (!this.entries.text || this.entries.text.startsWith('+ ')) {
-      this.entries.text = '+ ' + remaining;
-    }
-
     const entry = this.entries.entries[start + i];
     candidates.push({
       candidate:entry.word,

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -108,7 +108,11 @@ SKK.prototype.complete = function(dict_complete) {
       }
     }
   }
-  entries.push(...dict_complete(this.preedit + this.roman));
+  entries.sort((a, b) => b.length - a.length);
+  entries.push(
+    ...dict_complete(this.preedit + this.roman)
+    .sort((a, b) => b.length - a.length)
+  );
   if (entries.length > 0) {
     const candidates = ['', '', ''];
     candidates.push(...entries.filter((e, i) => entries.indexOf(e) == i));

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -126,15 +126,7 @@ SKK.prototype.complete = function(dict_complete, text) {
   );
   if (entries.length > 0) {
     const candidates = ['', '', ''];
-    const seen = new Set();
-    const uniqueEntries = [];
-    for (const e of entries) {
-      if (!seen.has(e)) {
-        seen.add(e);
-        uniqueEntries.push(e);
-      }
-    }
-    candidates.push(...uniqueEntries);
+    candidates.push(...new Set(entries));
     this.entries = {
       index:3,
       entries:candidates.map((e) => ({word:e})),

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -113,7 +113,7 @@ SKK.prototype.complete = function(dict_complete, text) {
   const entries = [];
   if (this.roman.length > 0) {
     for (var k in romanTable) {
-      if (k.indexOf(this.roman) == 0) {
+      if (k.startsWith(this.roman)) {
         entries.push(...dict_complete(this.preedit + romanTable[k]));
       }
     }

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -436,6 +436,10 @@ SKK.prototype.showStatus = function() {
       }
     }).catch((e) => console.log(e))
   ).then(() => {
+    chrome.input.ime.setCursorPosition({
+      contextID:this.context, candidateID:0
+    }).catch((e) => console.log(e));
+
     clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
       this.timeout = null;

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -125,7 +125,15 @@ SKK.prototype.complete = function(dict_complete, text) {
   );
   if (entries.length > 0) {
     const candidates = ['', '', ''];
-    candidates.push(...entries.filter((e, i) => entries.indexOf(e) == i));
+    const seen = new Set();
+    const uniqueEntries = [];
+    for (const e of entries) {
+      if (!seen.has(e)) {
+        seen.add(e);
+        uniqueEntries.push(e);
+      }
+    }
+    candidates.push(...uniqueEntries);
     this.entries = {
       index:3,
       entries:candidates.map((e) => ({word:e})),


### PR DESCRIPTION
まず、特別な操作なしに preedit で userDict から候補を表示します

その中からタブキー (ctrl-t) で次々と候補を選ぶかたちです
userDict の候補が終わったら次のタブキーは systemDict からの候補を表示します
ですので、userDict に候補がない場合は、タブを押すといきなり systemDict の候補になります

これを便利にするため、
変換確定時の候補がトップのときも recordNewResult が無視せず userDict に記録するようにします
こうすることによって、同じ変換を素早く入力できるようになります

短い変換にはあまり意味のない機能ですが、長い単語には初回から有効です

たとえば｢とくていほ｣でタブを打つことにより、
辞書に｢とくていほけんようしょくひん｣があることが分かりますし、
次回からは｢とくて｣程度まで打ってからタブで、一気に入力できるようになります