### PR TITLE
｢;｣による絞り込み

### DIFF
--- a/extension/conversion_modes.js
+++ b/extension/conversion_modes.js
@@ -18,9 +18,19 @@ function updateComposition(skk) {
 }
 
 function initConversion(skk) {
+  let hint = '';
+  const semicolon = skk.preedit.indexOf(';');
+  if (semicolon > 0) {
+    hint = skk.preedit.slice(semicolon + 1);
+    skk.preedit = skk.preedit.slice(0, semicolon);
+  }
   skk.lookup(skk.preedit + skk.okuriPrefix, function(entries) {
     if (entries) {
-      skk.entries = {index:0, entries:entries};
+      skk.entries = {
+        index:0,
+        entries:hint ? skk.narrowDown(entries, hint) : entries,
+        label:'asdfjkl'
+      };
       updateComposition(skk);
     } else {
       skk.createInnerSKK();

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -85,6 +85,15 @@ SKK.prototype.lookup = function(reading, callback) {
   }
 };
 
+SKK.prototype.narrowDown = function(entries, hint) {
+  const words = this.dictionary.lookup(hint);
+  if (!words) {
+    return [];
+  }
+  const kanjis = words.data.flatMap((w) => [...w.word]);
+  return entries.filter((e) => kanjis.some((k) => e.word.includes(k)));
+};
+
 SKK.prototype.processRoman = function (key, table, emitter) {
   function isStarting(key) {
     var starting = false;


### PR DESCRIPTION
同音異義語がたくさんあるときの絞り込みです
DDSKK に存在しているようです
https://ddskk.readthedocs.io/ja/latest/06_apps.html#skk-hint

｢かんどう｣には意外とたくさん候補があってスペースを何度も押すことになりますが
｢▽かんどう;あいだ｣でスペースを打つと｢間道｣だけになったり
｢▽かんどう;かんあつ｣で｢感動｣だけになるという機能です

｢わ｣も、｢▽わ;へいわ｣で｢和｣を一発変換できます

他の SKK 実装では、変換したあとに絞り込む機能もあり
個人的にはそちらの方が好きですが、
今回は少ない行数で実装できる正統派の仕様にしてみました