### PR TITLE
testpage.html 修正の方向性 (#35)

### DIFF
--- a/extension/ascii_modes.js
+++ b/extension/ascii_modes.js
@@ -23,7 +23,8 @@ function createAsciiLikeMode(conv) {
 SKK.registerMode('ascii', {
   displayName: '\u82f1\u6570',
   keyHandler: createAsciiLikeMode(function(skk, key) {
-    return false;
+    skk.commitText(key);
+    return true;
   })
 });
 

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -209,6 +209,15 @@ SKK.prototype.handleKeyEvent = function(keyevent) {
     }
   }
 
+  if (this.engineID == 'sample' && !consumed && keyevent.key == 'Backspace') {
+    chrome.input.ime.deleteSurroundingText({
+      contextID: this.context,
+      engineID: this.engineID,
+      length: 1,
+      offset: -1
+    });
+    consumed = true;
+  }
   this.updateComposition();
   this.updateCandidates();
   return consumed;

--- a/testpage/testpage.html
+++ b/testpage/testpage.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="../extension/roman_table.js"></script>
     <script type="text/javascript" src="../extension/roman_modes.js"></script>
     <script type="text/javascript" src="../extension/preedit_modes.js"></script>
-    <script type="text/javascript" src="../extension/pako.es5.min.js"></script>
+    <script type="text/javascript" src="../extension/pako_inflate.es5.min.js"></script>
     <script type="text/javascript" src="../extension/main.js"></script>
   </head>
   <body>


### PR DESCRIPTION
このまま取り入れてほしいというよりは、#35 の方向性のメモとしての PR です

- `Backspace` をスルーせず自前で処理する
  - `deleteSurroundingText` だと testpage 以外で問題がありそうなのでモックだけに限定してある
  - 具体的には Linux ターミナルで `Backspace` が利かなくなった
- ASCII をスルーせず `commitText` する
  - これも副作用があるかもしれないが、今のところ問題なく使えている気がする
- `chrome.storage` のモックを用意する
