### PR TITLE
context.shouldDoLearning を尊重する

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -25,6 +25,7 @@ chrome.input.ime.onFocus.addListener(function(context) {
       return true;
     }
     outer.context = context.contextID;
+    outer.private = !context.shouldDoLearning;
     if (setContext(outer.inner_skk, context)) {
       outer.showStatus();
     }

--- a/extension/skk.js
+++ b/extension/skk.js
@@ -11,6 +11,7 @@ function SKK(engineID, dictionary) {
   this.entries = null;
   this.dictionary = dictionary;
   this.timeout = null;
+  this.private = false;
 }
 
 SKK.prototype.commitText = function(text) {
@@ -310,6 +311,7 @@ SKK.prototype.createInnerSKK = function() {
 };
 
 SKK.prototype.recordNewResult = function(entry) {
+  if (this.private) return;
   this.dictionary.recordNewResult(this.preedit + this.okuriPrefix, entry);
 };
 
@@ -353,7 +355,7 @@ SKK.prototype.showStatus = function() {
     contextID:this.context,
     candidates:[{
       id:0,
-      label:"SKK",
+      label:this.private ? 'private' : 'SKK',
       candidate:this.currentMode
     }]
   }).then(() =>


### PR DESCRIPTION
Chrome シークレットウィンドウ等で漢字変換を userDict に記録しない
このモードのときは showStatus で private と表示する

手動で登録したくてもできないのはどうかと思うが

- createInnerSKK も冒頭で `this.private` だったら終了するか
- recordNewRecord に引数を増やして、innerSKK からの場合だけ強制的に記録を許すか

どちらにすべきか不明だったので放置してある
